### PR TITLE
Fix twitter data fetch should respect time range

### DIFF
--- a/src/Backend/SocialMediaDataFetch.py
+++ b/src/Backend/SocialMediaDataFetch.py
@@ -94,26 +94,26 @@ class TwitterDataFetch(SocialMediaDataFetch):
             # means the earliest tweet is later than the end date, need to keep extracting
             return True
         
-        earliest = len(tweets)
+        earliest = (len(tweets) - 1)
         latest = 0
         
         if (self._start_date > tweets[-1].created_at):
             earliest = self.__binary_search_get_time_index(tweets, self._start_date)
         
         if (self._end_date < tweets[0].created_at):
-            latest = self.__binary_search_get_time_index(tweets[:earliest], self._end_date) - 1
+            latest = self.__binary_search_get_time_index(tweets[:earliest], self._end_date)
             assert(latest >= 0) #prevent bug
         self.__format_data__(tweets[latest: earliest])
                 
-        return earliest != len(tweets)
+        return earliest == (len(tweets) - 1)
 
 
     def __binary_search_get_time_index(self, tweets, time):
-        start_point = len(tweets)
+        start_point = (len(tweets) - 1)
         end_point = 0
         pivot = (start_point + end_point)//2
         while (start_point - end_point > 1):
-            if (time > tweets[pivot].created_at):
+            if (time >= tweets[pivot].created_at):
                 start_point = pivot
             else:
                 end_point = pivot
@@ -144,19 +144,19 @@ class TwitterDataFetch(SocialMediaDataFetch):
 
 if __name__ == '__main__':
     dataFetch7 = TwitterDataFetch(start_date = datetime.datetime.now() - datetime.timedelta(days=1))
-    dataFetch7.fetch_user_posts("brecrossings")
+    dataFetch7.fetch_user_posts("panettonepapi")
     lst_7 = dataFetch7.get_data_lst()
 
     print(len(lst_7))
 
     dataFetch8 = TwitterDataFetch(start_date = datetime.datetime.now() - datetime.timedelta(days=2))
-    dataFetch8.fetch_user_posts("brecrossings")
+    dataFetch8.fetch_user_posts("panettonepapi")
     lst_8 = dataFetch8.get_data_lst()
 
     print(len(lst_8))
 
 
-    dataFetch7.fetch_user_posts("brecrossings")
+    dataFetch7.fetch_user_posts("panettonepapi")
     lst_7 = dataFetch7.get_data_lst()
 
     print(len(lst_7))


### PR DESCRIPTION
- Fix one extra tweet outside of date range by updating `lastest` field in `__filter_data_by_time__`
- Fix not getting all the tweets in the time range by fixing `keepRequesting` logic so it keeps getting user's tweets when it is still within the time range

Now the API call returns correct objects:
![Screen Shot 2021-04-17 at 4 52 17 PM](https://user-images.githubusercontent.com/22476453/115126545-d3fa2500-9f9d-11eb-8538-9e8078264791.png)
 